### PR TITLE
feat: productboard releated patches

### DIFF
--- a/lib/audited_async.rb
+++ b/lib/audited_async.rb
@@ -34,14 +34,9 @@ module AuditedAsync
 end
 
 module Audited::Auditor::ClassMethods
-  attr_reader :audited_async_enabled
-
-  _audited = instance_method :audited
-
-  define_method :audited do |options = {}|
-    @audited_async_enabled = options.fetch(:async, false) && AuditedAsync.config.enabled?
-
-    _audited.bind(self).call(options)
+  def audited_async_enabled
+    return @audited_async_enabled if defined?(@audited_async_enabled)
+    @audited_async_enabled ||= audited_options.fetch(:async, false) && AuditedAsync.config.enabled?
   end
 
   alias audited_async_enabled? audited_async_enabled
@@ -79,8 +74,7 @@ module Audited::Auditor::AuditedInstanceMethods
   def perform_async_audit(method, changes = nil)
     AuditedAsync.config
                 .job
-                .set(AuditedAsync.config.job_options)
-                .perform_later class_name: self.class.name,
+                .perform_async class_name: self.class.name,
                                record_id: send(self.class.primary_key.to_sym),
                                action: method,
                                audited_changes: (changes || audited_attributes).to_json,

--- a/lib/audited_async.rb
+++ b/lib/audited_async.rb
@@ -81,7 +81,7 @@ module Audited::Auditor::AuditedInstanceMethods
                 .perform_in(
                   # Works with wait = nil, wait = Time.now, wait = 2.seconds
                   job_options && job_options[:wait],
-                  audite_attributes.merge(
+                  audit_attributes.merge(
                     class_name:      self.class.name,
                     record_id:       send(self.class.primary_key.to_sym),
                     action:          method,
@@ -92,16 +92,20 @@ module Audited::Auditor::AuditedInstanceMethods
                 )
   end
 
-  def audite_attributes
+  def audit_attributes
     user = audit_current_user
 
     {
-      space_id:       RequestStore[:current_space_id],
+      space_id:       audit_space_id,
       remote_address: ::Audited.store[:current_remote_address],
       request_uuid:   ::Audited.store[:current_request_uuid],
       user_type:      user && user.class.to_s,
       user_id:        user && user.id
     }
+  end
+
+  def audit_space_id
+    try(:space_id) || RequestStore[:current_space_id]
   end
 
   # https://github.com/collectiveidea/audited/blob/07209850986353b60adc3789ee7fa8c02b338e41/lib/audited/audit.rb#L179

--- a/lib/audited_async.rb
+++ b/lib/audited_async.rb
@@ -86,7 +86,8 @@ module Audited::Auditor::AuditedInstanceMethods
                     record_id:       send(self.class.primary_key.to_sym),
                     action:          method,
                     audited_changes: (changes || audited_attributes).to_json,
-                    comment:         audit_comment
+                    comment:         audit_comment,
+                    name:            try(:name) || try(:title)
                   )
                 )
   end

--- a/lib/audited_async.rb
+++ b/lib/audited_async.rb
@@ -72,6 +72,8 @@ module Audited::Auditor::AuditedInstanceMethods
   end
 
   def perform_async_audit(method, changes = nil)
+    return unless auditing_enabled
+
     job_options = AuditedAsync.config.job_options
 
     AuditedAsync.config


### PR DESCRIPTION
1. the logic behind audited_async_enabled? was somehow broken with our
setup and randomly changed from returning true into returning nil.

2. The default Job which it can work with is ActiveJob library which we
do not use. I change id to support sidekiq jobs.